### PR TITLE
Update to rules apple to 2.0

### DIFF
--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -142,9 +142,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
         http_archive,
         name = "xctestrunner",
         urls = [
-            "https://github.com/bazel-ios/xctestrunner/archive/dfba2695f1ba5930290dd48280d80c06dcdd4ccb.tar.gz",
+            "https://github.com/bazel-ios/xctestrunner/archive/95dba5afa60647e9d83da8ade9fedace75824002.tar.gz",
         ],
-        strip_prefix = "xctestrunner-dfba2695f1ba5930290dd48280d80c06dcdd4ccb",
-        sha256 = "cb4dd37fcb71a36c4ccffb0b91d403c34cad14711657e48a0f2e48d9eb5c61a0",
+        strip_prefix = "xctestrunner-95dba5afa60647e9d83da8ade9fedace75824002",
+        sha256 = "89070cb69c5ced5fbdffa84b9f7ad4a6b39e29076569b6e5b17cd448c94763f6",
         ignore_version_differences = ignore_version_differences,
     )

--- a/apple/repositories.bzl
+++ b/apple/repositories.bzl
@@ -142,9 +142,9 @@ def apple_rules_dependencies(ignore_version_differences = False):
         http_archive,
         name = "xctestrunner",
         urls = [
-            "https://github.com/google/xctestrunner/archive/e0bc4b29976cf000794e9e796cb8a584b0c443bc.tar.gz",
+            "https://github.com/bazel-ios/xctestrunner/archive/dfba2695f1ba5930290dd48280d80c06dcdd4ccb.tar.gz",
         ],
-        strip_prefix = "xctestrunner-e0bc4b29976cf000794e9e796cb8a584b0c443bc",
-        sha256 = "6cd157ae7523d024eeb7ec05811979e9c191597f061a80244041374e10ebca13",
+        strip_prefix = "xctestrunner-dfba2695f1ba5930290dd48280d80c06dcdd4ccb",
+        sha256 = "cb4dd37fcb71a36c4ccffb0b91d403c34cad14711657e48a0f2e48d9eb5c61a0",
         ignore_version_differences = ignore_version_differences,
     )

--- a/apple/testing/default_runner/ios_test_runner.template.sh
+++ b/apple/testing/default_runner/ios_test_runner.template.sh
@@ -52,6 +52,11 @@ TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/test_runner_work_dir.XXXXXX")"
 trap 'rm -rf "${TMP_DIR}"' ERR EXIT
 runner_flags+=("--work_dir=${TMP_DIR}")
 
+PRODUCT_MODULE_NAME="%(product_module_name)s"
+if [[ -n "$PRODUCT_MODULE_NAME" ]]; then
+  runner_flags+=("--product_module_name=${PRODUCT_MODULE_NAME}")
+fi
+
 TEST_BUNDLE_PATH="%(test_bundle_path)s"
 
 if [[ "$TEST_BUNDLE_PATH" == *.xctest ]]; then


### PR DESCRIPTION
This starts off of the rules_apple 2.0 release and cherry picks the following 3 commits for our fork:

```
➜  rules_apple git:(dostrander/update-to-rules_apple_to_2.0) git cherry-pick 065c8dff7cae4229589dede4b64a03e4614d2e2e
Auto-merging apple/internal/testing/apple_test_rule_support.bzl
Auto-merging apple/testing/default_runner/ios_test_runner.template.sh
[dostrander/update-to-rules_apple_to_2.0 7eb077d3] Grab module name from swiftmodule files (#1)
 Author: Derek Ostrander (derko) <djostran@gmail.com>
 Date: Wed Jan 4 13:45:34 2023 -0500
 2 files changed, 19 insertions(+), 1 deletion(-)
➜  rules_apple git:(dostrander/update-to-rules_apple_to_2.0) git cherry-pick 19bdc2bed14d35fff01fe041ba6be1b9b897377b
Auto-merging apple/repositories.bzl
[dostrander/update-to-rules_apple_to_2.0 5eb2ae11] Use bazel-ios/xctestrunner (#2)
 Author: Derek Ostrander (derko) <djostran@gmail.com>
 Date: Wed Jan 4 16:02:18 2023 -0500
 1 file changed, 3 insertions(+), 3 deletions(-)
➜  rules_apple git:(dostrander/update-to-rules_apple_to_2.0) git cherry-pick e83ecfeb4f0f18357713394f2d71b7c2d8ee779f
Auto-merging apple/repositories.bzl
[dostrander/update-to-rules_apple_to_2.0 6110aada] Update xctestunner (#3)
 Author: Derek Ostrander (derko) <djostran@gmail.com>
 Date: Thu Jan 5 17:22:44 2023 -0500
 1 file changed, 3 insertions(+), 3 deletions(-)
```